### PR TITLE
Server done channel is now handled entirely within the package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONEY: test
 test:
+	docker-compose run api go test ./... -short
+
+.PHONEY: integration
+integration:
 	docker-compose run api go test ./...

--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ docker-compose up
 ```
 
 ### Tests
-To run the test suite use the command
+To run the unit tests use the command
 ```bash
 make test
 ```
+
+To run the entire test suite including the integration tests run
+```bash
+make integration
+```
+The integration tests take ~15 seconds to run. 
 

--- a/api/handler/handler_test.go
+++ b/api/handler/handler_test.go
@@ -44,8 +44,7 @@ func TestShutDown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	done := make(chan bool, 1)
-	mockServer := server.New(done, "3000")
+	mockServer := server.New("3000")
 	rr := httptest.NewRecorder()
 	handler := ShutDown(mockServer)
 

--- a/api/main.go
+++ b/api/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/user/api/router"
@@ -24,13 +23,10 @@ func init() {
 }
 
 func main() {
-	done := make(chan bool, 1)
 	sStats := stats.New()
-	server := server.New(done, apiPort)
+	server := server.New(apiPort)
 	router := router.CreateRouter(sStats, server)
 	server.RegisterRoutes(router)
 	server.Start()
-	<-done
-	log.Println("api shutdown exiting")
 	os.Exit(0)
 }

--- a/api/router/end_to_end_test.go
+++ b/api/router/end_to_end_test.go
@@ -25,9 +25,12 @@ func newreq(t *testing.T, method, url string, body io.Reader) *http.Request {
 }
 
 func TestEndToEnd(t *testing.T) {
-	done := make(chan bool, 1)
+	if testing.Short() {
+		t.Skip("skipping integration tests in short mode.")
+	}
+
 	sStats := stats.New()
-	serv := server.New(done, "8080")
+	serv := server.New("8080")
 	routes := CreateRouter(sStats, serv)
 	serv.RegisterRoutes(routes)
 	testServer := httptest.NewUnstartedServer(routes)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 )
@@ -13,7 +12,8 @@ type Api struct {
 	Mux    *http.ServeMux
 }
 
-func New(done chan bool, port string) Api {
+func New(port string) Api {
+	done := make(chan bool, 1)
 	httpServer := &http.Server{
 		Addr: ":" + port,
 	}
@@ -29,18 +29,21 @@ func (serv Api) RegisterRoutes(mux *http.ServeMux) {
 }
 
 // Start the api server beings listening for requests
+// Blocks until Shutdown has finished
 func (serv Api) Start() {
 	log.Println("listening on " + serv.Server.Addr)
 	if err := serv.Server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("Error listening on %v %v\n", serv.Server.Addr, err)
 	}
+	<-serv.Done
 }
 
 func (serv Api) ShutDown() {
-	fmt.Println("shutting the server down")
+	log.Println("shutting the server down")
 	serv.Server.SetKeepAlivesEnabled(false)
 	if err := serv.Server.Shutdown(context.Background()); err != nil {
 		log.Fatal(err)
 	}
+	log.Println("server down has shutdown")
 	serv.Done <- true
 }


### PR DESCRIPTION
end_to_end tests now only get triggered when the -short tag is not included.